### PR TITLE
Update stylelint to 11.1.1 to meet peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
     "pre-commit": "^1.2.2",
     "rollup": "^1.11.3",
     "rollup-plugin-babel": "^4.3.2",
-    "stylelint": "^10.0.1",
+    "stylelint": "^11.1.1",
     "stylelint-tape": "^1.0.2"
   },
   "peerDependencies": {
-    "stylelint": "^10.0.1"
+    "stylelint": "^11.1.1"
   },
   "eslintConfig": {
     "extends": "dev",


### PR DESCRIPTION
After updating stylelint to 11.1.1 I received the following error message

`npm ERR! peer dep missing: stylelint@^9.6.0, required by stylelint-use-logical@1.1.0`

Problem was solved by increasing stylelint-use-logical package.json from version 10.0.1 to 11.1.1 both in devDependencies and peerDependencies.

I ran npm test and found no errors. 

