### PR TITLE
Fix autofix of inset/margin/padding with 4 physical values

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,24 +53,24 @@ function ruleFunc(method, opts, context) {
 						const firstInlineDecl = blockStartDecl;
 
 						if (isAutofix) {
-							const values = [ blockStartDecl.value, inlineStartDecl.value, blockEndDecl.value, inlineEndDecl.value ];
+							const values = [ blockStartDecl.value, inlineEndDecl.value, blockEndDecl.value, inlineStartDecl.value ];
 
-							if (values[1] === values[3]) {
-								values.pop();
+              if (values[1] === values[3]) {
+                values.pop();
 
-								if (values[2] === values[1]) {
-									values.pop();
+                if (values[0] === values[2]) {
+                  values.pop();
 
-									if (values[1] === values[0]) {
-										values.pop();
-									}
-								}
-							}
+                  if (values[0] === values[1]) {
+                    values.pop();
+                  }
+                }
+              }
 
-							firstInlineDecl.cloneBefore({
-								prop,
-								value: values.length <= 2 ? values.join(' ') : `logical ${values.join(' ')}`
-							});
+              firstInlineDecl.cloneBefore({
+                prop,
+                value: values.join(' ')
+              });
 
 							blockStartDecl.remove();
 							inlineStartDecl.remove();


### PR DESCRIPTION
Fixes https://github.com/csstools/stylelint-use-logical/issues/32

`inset/margin/padding` expects top-right-bottom-left ordering `physical4Prop` has top-left-bottom-right order.

As far as I understand `validateRuleWithProps` ensures that we always get 4 declarations so no need to check `values` length for less than 4 elements.

The declaration value shortening is fixed to work with top-right-bottom-left order so the shortening can proceed as:
```bash
# top right bottom left => top right/left bottom
10px 20px 30px 20px => 10px 20px 30px
# top right/left bottom => top/bottom right/left
10px 20px 10px => 10px 20px
# top/bottom right/left => all
10px 10px => 10px
```